### PR TITLE
ci: speed up interchaintest by skipping arm builds

### DIFF
--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -12,10 +12,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -35,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push-image
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v3
         with:
           go-version: 1.21
@@ -51,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push-image
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v3
         with:
           go-version: 1.21
@@ -67,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push-image
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v3
         with:
           go-version: 1.21

--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -24,7 +24,7 @@ jobs:
           file: Dockerfile
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             osmolabs/fee-abstraction-ictest:latest
   test-basic:

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -27,6 +27,12 @@ jobs:
       - 
         name: Check out the repo
         uses: actions/checkout@v3
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -27,12 +27,7 @@ jobs:
       - 
         name: Check out the repo
         uses: actions/checkout@v3
-      - 
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - 
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -58,7 +53,7 @@ jobs:
           file: Dockerfile
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             osmolabs/fee-abstraction:${{ env.MAJOR_VERSION }}
             osmolabs/fee-abstraction:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -6,7 +6,7 @@
 # osmosis-labs/fee-abstraction:X.Y      # is updated to X.Y.Z
 # osmosis-labs/fee-abstraction:X        # is updated to X.Y.Z
 # osmosis-labs/fee-abstraction:latest   # is updated to X.Y.Z
-# 
+#
 # All the images above have support for linux/amd64 and linux/arm64.
 #
 # Due to QEMU virtualization used to build multi-platform docker images
@@ -19,19 +19,16 @@ on:
     types: [published, created, edited]
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+' # ignore rc
+      - 'v[0-9]+.[0-9]+.[0-9]+' # ignore rc
 jobs:
   feeapp-images:
     runs-on: ubuntu-latest
     steps:
-      - 
-        name: Check out the repo
+      - name: Check out the repo
         uses: actions/checkout@v3
-      - 
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      - 
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
@@ -39,8 +36,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Parse tag
+      - name: Parse tag
         id: tag
         run: |
           VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
@@ -51,15 +47,14 @@ jobs:
           echo "MAJOR_VERSION=$MAJOR_VERSION" >> $GITHUB_ENV
           echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
           echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
-      - 
-        name: Build and push 
+      - name: Build and push
         id: build_push_image
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             osmolabs/fee-abstraction:${{ env.MAJOR_VERSION }}
             osmolabs/fee-abstraction:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}


### PR DESCRIPTION
This will help progress on 

#60 

This PR removes the arm64 support for interchaintest, which should shave more than 10 minutes off of the time to build and push the docker image. 