### PR TITLE
fix bug ack when adding new hostzone right after send ibc query

### DIFF
--- a/scripts/host_zone_uosmo.json
+++ b/scripts/host_zone_uosmo.json
@@ -1,0 +1,12 @@
+{
+	"title": "Add Fee Abbtraction Host Zone Proposal",
+	"description": "Add Fee Abbtraction Host Zone",
+	"host_chain_fee_abs_config": 
+		{
+			"ibc_denom": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
+			"osmosis_pool_token_denom_in": "uosmo",
+			"pool_id": "1",
+			"frozen": false
+		},
+	"deposit": "100000000stake"
+}

--- a/x/feeabs/ibc_module.go
+++ b/x/feeabs/ibc_module.go
@@ -205,11 +205,12 @@ func (am IBCModule) OnTimeoutPacket(
 	packet channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) error {
-	params := am.keeper.GetParams(ctx)
-	chancap := am.keeper.GetCapability(ctx, host.ChannelCapabilityPath(types.IBCPortID, params.IbcQueryIcqChannel))
+	var icqPacketData types.InterchainQueryPacketData
+	if err := types.ModuleCdc.UnmarshalJSON(packet.GetData(), &icqPacketData); err != nil {
+		return sdkerrors.Wrapf(errorstypes.ErrUnknownRequest, "cannot unmarshal packet data: %v", err)
+	}
 	// Resend request if timeout
-	err := am.keeper.OnTimeoutPacket(ctx, chancap, packet.SourcePort, packet.SourceChannel,
-		packet.TimeoutHeight, packet.TimeoutTimestamp, packet.Data) // If there is an error here we should still handle the timeout
+	err := am.keeper.OnTimeoutPacket(ctx)
 	if err != nil {
 		am.keeper.Logger(ctx).Error(fmt.Sprintf("Error OnTimeoutPacket %s", err.Error()))
 		ctx.EventManager().EmitEvent(

--- a/x/feeabs/keeper/config.go
+++ b/x/feeabs/keeper/config.go
@@ -59,9 +59,15 @@ func (k Keeper) SetHostZoneConfig(ctx sdk.Context, chainConfig types.HostChainFe
 }
 
 func (k Keeper) DeleteHostZoneConfig(ctx sdk.Context, ibcDenom string) error {
+	hostZoneConfig, _ := k.GetHostZoneConfig(ctx, ibcDenom)
 	store := ctx.KVStore(k.storeKey)
+
 	key := types.GetKeyHostZoneConfigByFeeabsIBCDenom(ibcDenom)
 	store.Delete(key)
+
+	key = types.GetKeyHostZoneConfigByOsmosisIBCDenom(hostZoneConfig.OsmosisPoolTokenDenomIn)
+	store.Delete(key)
+
 	return nil
 }
 

--- a/x/feeabs/keeper/config.go
+++ b/x/feeabs/keeper/config.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	sdkerrors "cosmossdk.io/errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/fee-abstraction/v7/x/feeabs/types"
@@ -14,32 +12,34 @@ func (k Keeper) HasHostZoneConfig(ctx sdk.Context, ibcDenom string) bool {
 	return store.Has(key)
 }
 
-func (k Keeper) GetHostZoneConfig(ctx sdk.Context, ibcDenom string) (chainConfig types.HostChainFeeAbsConfig, err error) {
+func (k Keeper) GetHostZoneConfig(ctx sdk.Context, ibcDenom string) (types.HostChainFeeAbsConfig, bool) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.GetKeyHostZoneConfigByFeeabsIBCDenom(ibcDenom)
 
+	var chainConfig types.HostChainFeeAbsConfig
 	bz := store.Get(key)
-	err = k.cdc.Unmarshal(bz, &chainConfig)
-
-	if err != nil {
-		return types.HostChainFeeAbsConfig{}, err
+	if bz == nil {
+		return types.HostChainFeeAbsConfig{}, false
 	}
 
-	return chainConfig, nil
+	k.cdc.MustUnmarshal(bz, &chainConfig)
+
+	return chainConfig, true
 }
 
-func (k Keeper) GetHostZoneConfigByOsmosisTokenDenom(ctx sdk.Context, osmosisIbcDenom string) (chainConfig types.HostChainFeeAbsConfig, err error) {
+func (k Keeper) GetHostZoneConfigByOsmosisTokenDenom(ctx sdk.Context, osmosisIbcDenom string) (types.HostChainFeeAbsConfig, bool) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.GetKeyHostZoneConfigByOsmosisIBCDenom(osmosisIbcDenom)
 
+	var chainConfig types.HostChainFeeAbsConfig
 	bz := store.Get(key)
-	err = k.cdc.Unmarshal(bz, &chainConfig)
-
-	if err != nil {
-		return types.HostChainFeeAbsConfig{}, err
+	if bz == nil {
+		return types.HostChainFeeAbsConfig{}, false
 	}
 
-	return chainConfig, nil
+	k.cdc.MustUnmarshal(bz, &chainConfig)
+
+	return chainConfig, true
 }
 
 func (k Keeper) SetHostZoneConfig(ctx sdk.Context, chainConfig types.HostChainFeeAbsConfig) error {
@@ -102,12 +102,12 @@ func (k Keeper) IterateHostZone(ctx sdk.Context, cb func(hostZoneConfig types.Ho
 }
 
 func (k Keeper) FrozenHostZoneByIBCDenom(ctx sdk.Context, ibcDenom string) error {
-	hostChainConfig, err := k.GetHostZoneConfig(ctx, ibcDenom)
-	if err != nil {
-		return sdkerrors.Wrapf(types.ErrHostZoneConfigNotFound, err.Error())
+	hostChainConfig, found := k.GetHostZoneConfig(ctx, ibcDenom)
+	if !found {
+		return types.ErrHostZoneConfigNotFound
 	}
 	hostChainConfig.Frozen = true
-	err = k.SetHostZoneConfig(ctx, hostChainConfig)
+	err := k.SetHostZoneConfig(ctx, hostChainConfig)
 	if err != nil {
 		return err
 	}
@@ -116,12 +116,12 @@ func (k Keeper) FrozenHostZoneByIBCDenom(ctx sdk.Context, ibcDenom string) error
 }
 
 func (k Keeper) UnFrozenHostZoneByIBCDenom(ctx sdk.Context, ibcDenom string) error {
-	hostChainConfig, err := k.GetHostZoneConfig(ctx, ibcDenom)
-	if err != nil {
-		return sdkerrors.Wrapf(types.ErrHostZoneConfigNotFound, err.Error())
+	hostChainConfig, found := k.GetHostZoneConfig(ctx, ibcDenom)
+	if !found {
+		return types.ErrHostZoneConfigNotFound
 	}
 	hostChainConfig.Frozen = false
-	err = k.SetHostZoneConfig(ctx, hostChainConfig)
+	err := k.SetHostZoneConfig(ctx, hostChainConfig)
 	if err != nil {
 		return err
 	}

--- a/x/feeabs/keeper/grpc_query.go
+++ b/x/feeabs/keeper/grpc_query.go
@@ -65,9 +65,9 @@ func (q Querier) HostChainConfig(goCtx context.Context, req *types.QueryHostChai
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	hostChainConfig, err := q.GetHostZoneConfig(ctx, req.IbcDenom)
-	if err != nil {
-		return nil, err
+	hostChainConfig, found := q.GetHostZoneConfig(ctx, req.IbcDenom)
+	if !found {
+		return nil, types.ErrHostZoneConfigNotFound
 	}
 
 	return &types.QueryHostChainConfigRespone{

--- a/x/feeabs/keeper/grpc_query_test.go
+++ b/x/feeabs/keeper/grpc_query_test.go
@@ -64,7 +64,7 @@ func (s *KeeperTestSuite) TestHostChainConfig() {
 		PoolId:                  randUint64Num(),
 	}
 
-	err := s.feeAbsKeeper.SetHostZoneConfig(s.ctx, chainConfig.IbcDenom, chainConfig)
+	err := s.feeAbsKeeper.SetHostZoneConfig(s.ctx, chainConfig)
 	s.Require().NoError(err)
 
 	for _, tc := range []struct {

--- a/x/feeabs/keeper/grpc_query_test.go
+++ b/x/feeabs/keeper/grpc_query_test.go
@@ -103,7 +103,7 @@ func (s *KeeperTestSuite) TestHostChainConfig() {
 				s.Require().Equal(tc.res, res)
 			} else {
 				_, err := s.queryClient.HostChainConfig(goCtx, tc.req)
-				s.Require().NoError(err)
+				s.Require().Error(err)
 			}
 		})
 	}

--- a/x/feeabs/keeper/host_zone_test.go
+++ b/x/feeabs/keeper/host_zone_test.go
@@ -23,7 +23,7 @@ func createNHostZone(t *testing.T, keeper *feeabskeeper.Keeper, ctx sdk.Context,
 	}
 	for i := 0; i < n; i++ {
 		expected = append(expected, expectedConfig)
-		err := keeper.SetHostZoneConfig(ctx, expectedConfig.IbcDenom, expectedConfig)
+		err := keeper.SetHostZoneConfig(ctx, expectedConfig)
 		require.NoError(t, err)
 	}
 	return expected
@@ -35,6 +35,17 @@ func TestHostZoneGet(t *testing.T) {
 	expected := createNHostZone(t, &app.FeeabsKeeper, ctx, 1)
 	for _, item := range expected {
 		got, err := app.FeeabsKeeper.GetHostZoneConfig(ctx, item.IbcDenom)
+		require.NoError(t, err)
+		require.Equal(t, item, got)
+	}
+}
+
+func TestHostZoneGetByOsmosisDenom(t *testing.T) {
+	app := apphelpers.Setup(t, false, 1)
+	ctx := apphelpers.NewContextForApp(*app)
+	expected := createNHostZone(t, &app.FeeabsKeeper, ctx, 1)
+	for _, item := range expected {
+		got, err := app.FeeabsKeeper.GetHostZoneConfigByOsmosisTokenDenom(ctx, item.OsmosisPoolTokenDenomIn)
 		require.NoError(t, err)
 		require.Equal(t, item, got)
 	}

--- a/x/feeabs/keeper/host_zone_test.go
+++ b/x/feeabs/keeper/host_zone_test.go
@@ -58,8 +58,10 @@ func TestHostZoneRemove(t *testing.T) {
 	for _, item := range expected {
 		err := app.FeeabsKeeper.DeleteHostZoneConfig(ctx, item.IbcDenom)
 		require.NoError(t, err)
-		got, _ := app.FeeabsKeeper.GetHostZoneConfig(ctx, item.IbcDenom)
-		require.NotEqual(t, item, got)
+		_, found := app.FeeabsKeeper.GetHostZoneConfig(ctx, item.IbcDenom)
+		require.False(t, found)
+		_, found = app.FeeabsKeeper.GetHostZoneConfigByOsmosisTokenDenom(ctx, item.OsmosisPoolTokenDenomIn)
+		require.False(t, found)
 	}
 }
 

--- a/x/feeabs/keeper/host_zone_test.go
+++ b/x/feeabs/keeper/host_zone_test.go
@@ -34,8 +34,8 @@ func TestHostZoneGet(t *testing.T) {
 	ctx := apphelpers.NewContextForApp(*app)
 	expected := createNHostZone(t, &app.FeeabsKeeper, ctx, 1)
 	for _, item := range expected {
-		got, err := app.FeeabsKeeper.GetHostZoneConfig(ctx, item.IbcDenom)
-		require.NoError(t, err)
+		got, found := app.FeeabsKeeper.GetHostZoneConfig(ctx, item.IbcDenom)
+		require.True(t, found)
 		require.Equal(t, item, got)
 	}
 }
@@ -45,8 +45,8 @@ func TestHostZoneGetByOsmosisDenom(t *testing.T) {
 	ctx := apphelpers.NewContextForApp(*app)
 	expected := createNHostZone(t, &app.FeeabsKeeper, ctx, 1)
 	for _, item := range expected {
-		got, err := app.FeeabsKeeper.GetHostZoneConfigByOsmosisTokenDenom(ctx, item.OsmosisPoolTokenDenomIn)
-		require.NoError(t, err)
+		got, found := app.FeeabsKeeper.GetHostZoneConfigByOsmosisTokenDenom(ctx, item.OsmosisPoolTokenDenomIn)
+		require.True(t, found)
 		require.Equal(t, item, got)
 	}
 }

--- a/x/feeabs/keeper/ibc.go
+++ b/x/feeabs/keeper/ibc.go
@@ -127,7 +127,7 @@ func (k Keeper) OnAcknowledgementPacket(ctx sdk.Context, ack channeltypes.Acknow
 			// get chain config
 			hostZoneConfig, found := k.GetHostZoneConfigByOsmosisTokenDenom(ctx, icqReqData.QuoteAsset)
 			if !found {
-				k.Logger(ctx).Error(fmt.Sprintf("Error when get host zone by Osmosis denom %s %v not found", icqReqData.BaseAsset, err))
+				k.Logger(ctx).Error(fmt.Sprintf("Error when get host zone by Osmosis denom %s %v not found", icqReqData.QuoteAsset, err))
 				continue
 			}
 
@@ -185,6 +185,11 @@ func (k Keeper) OnAcknowledgementPacket(ctx sdk.Context, ack channeltypes.Acknow
 		)
 	}
 	return nil
+}
+
+// OnTimeoutPacket resend packet when timeout
+func (k Keeper) OnTimeoutPacket(ctx sdk.Context) error {
+	return k.handleOsmosisIbcQuery(ctx)
 }
 
 func (k Keeper) GetChannelID(ctx sdk.Context) string {

--- a/x/feeabs/keeper/ibc.go
+++ b/x/feeabs/keeper/ibc.go
@@ -125,9 +125,9 @@ func (k Keeper) OnAcknowledgementPacket(ctx sdk.Context, ack channeltypes.Acknow
 			}
 
 			// get chain config
-			hostZoneConfig, err := k.GetHostZoneConfigByOsmosisTokenDenom(ctx, icqReqData.QuoteAsset)
-			if err != nil {
-				k.Logger(ctx).Error(fmt.Sprintf("Error when get host zone by Osmosis denom %s %v", icqReqData.BaseAsset, err))
+			hostZoneConfig, found := k.GetHostZoneConfigByOsmosisTokenDenom(ctx, icqReqData.QuoteAsset)
+			if !found {
+				k.Logger(ctx).Error(fmt.Sprintf("Error when get host zone by Osmosis denom %s %v not found", icqReqData.BaseAsset, err))
 				continue
 			}
 

--- a/x/feeabs/keeper/ibc.go
+++ b/x/feeabs/keeper/ibc.go
@@ -187,27 +187,6 @@ func (k Keeper) OnAcknowledgementPacket(ctx sdk.Context, ack channeltypes.Acknow
 	return nil
 }
 
-func (k Keeper) getQueryArithmeticTwapToNowRequest(
-	ctx sdk.Context,
-	icqReqs []abci.RequestQuery,
-	index int,
-) (types.QueryArithmeticTwapToNowRequest, int, bool) {
-	packetLen := len(icqReqs)
-	found := false
-	var icqReqData types.QueryArithmeticTwapToNowRequest
-	for (index < packetLen) && (!found) {
-		icqReq := icqReqs[index]
-		if err := k.cdc.Unmarshal(icqReq.GetData(), &icqReqData); err != nil {
-			k.Logger(ctx).Error(fmt.Sprintf("Failed to unmarshal icqReqData %s", err.Error()))
-			index++
-		} else {
-			found = true
-		}
-	}
-
-	return icqReqData, index, found
-}
-
 func (k Keeper) GetChannelID(ctx sdk.Context) string {
 	store := ctx.KVStore(k.storeKey)
 	return string(store.Get(types.KeyChannelID))

--- a/x/feeabs/keeper/keeper.go
+++ b/x/feeabs/keeper/keeper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	ibctransferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
-	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -128,15 +127,6 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 // SetParams sets all of the parameters in the abstraction module.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
-}
-
-// OnTimeoutPacket resend packet when timeout
-func (k Keeper) OnTimeoutPacket(ctx sdk.Context, chanCap *capabilitytypes.Capability, sourcePort string,
-	sourceChannel string, timeoutHeight clienttypes.Height, timeoutTimestamp uint64, packetData []byte,
-) error {
-	_, err := k.channelKeeper.SendPacket(ctx, chanCap, sourcePort, sourceChannel,
-		timeoutHeight, timeoutTimestamp, packetData)
-	return err
 }
 
 func (k Keeper) GetCapability(ctx sdk.Context, name string) *capabilitytypes.Capability {

--- a/x/feeabs/keeper/msgserver.go
+++ b/x/feeabs/keeper/msgserver.go
@@ -38,11 +38,11 @@ func (k Keeper) SendQueryIbcDenomTWAP(goCtx context.Context, msg *types.MsgSendQ
 
 func (k Keeper) SwapCrossChain(goCtx context.Context, msg *types.MsgSwapCrossChain) (*types.MsgSwapCrossChainResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	hostChainConfig, err := k.GetHostZoneConfig(ctx, msg.IbcDenom)
-	if err != nil {
-		return &types.MsgSwapCrossChainResponse{}, nil
+	hostChainConfig, found := k.GetHostZoneConfig(ctx, msg.IbcDenom)
+	if !found {
+		return &types.MsgSwapCrossChainResponse{}, types.ErrHostZoneConfigNotFound
 	}
-	_, err = sdk.AccAddressFromBech32(msg.FromAddress)
+	_, err := sdk.AccAddressFromBech32(msg.FromAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/x/feeabs/keeper/proposal.go
+++ b/x/feeabs/keeper/proposal.go
@@ -21,12 +21,12 @@ func (k Keeper) AddHostZoneProposal(ctx sdk.Context, p *types.AddHostZoneProposa
 }
 
 func (k Keeper) DeleteHostZoneProposal(ctx sdk.Context, p *types.DeleteHostZoneProposal) error {
-	_, err := k.GetHostZoneConfig(ctx, p.IbcDenom)
-	if err == nil {
+	_, found := k.GetHostZoneConfig(ctx, p.IbcDenom)
+	if !found {
 		return types.ErrHostZoneConfigNotFound
 	}
 
-	err = k.DeleteHostZoneConfig(ctx, p.IbcDenom)
+	err := k.DeleteHostZoneConfig(ctx, p.IbcDenom)
 	if err != nil {
 		return err
 	}
@@ -35,12 +35,12 @@ func (k Keeper) DeleteHostZoneProposal(ctx sdk.Context, p *types.DeleteHostZoneP
 }
 
 func (k Keeper) SetHostZoneProposal(ctx sdk.Context, p *types.SetHostZoneProposal) error {
-	_, err := k.GetHostZoneConfig(ctx, p.HostChainConfig.IbcDenom)
-	if err == nil {
+	_, found := k.GetHostZoneConfig(ctx, p.HostChainConfig.IbcDenom)
+	if !found {
 		return types.ErrHostZoneConfigNotFound
 	}
 
-	err = k.SetHostZoneConfig(ctx, *p.HostChainConfig)
+	err := k.SetHostZoneConfig(ctx, *p.HostChainConfig)
 	if err != nil {
 		return err
 	}

--- a/x/feeabs/keeper/proposal.go
+++ b/x/feeabs/keeper/proposal.go
@@ -7,8 +7,8 @@ import (
 )
 
 func (k Keeper) AddHostZoneProposal(ctx sdk.Context, p *types.AddHostZoneProposal) error {
-	config, _ := k.GetHostZoneConfig(ctx, p.HostChainConfig.IbcDenom)
-	if (config != types.HostChainFeeAbsConfig{}) {
+	_, found := k.GetHostZoneConfig(ctx, p.HostChainConfig.IbcDenom)
+	if found {
 		return types.ErrDuplicateHostZoneConfig
 	}
 

--- a/x/feeabs/keeper/proposal.go
+++ b/x/feeabs/keeper/proposal.go
@@ -12,7 +12,7 @@ func (k Keeper) AddHostZoneProposal(ctx sdk.Context, p *types.AddHostZoneProposa
 		return types.ErrDuplicateHostZoneConfig
 	}
 
-	err := k.SetHostZoneConfig(ctx, p.HostChainConfig.IbcDenom, *p.HostChainConfig)
+	err := k.SetHostZoneConfig(ctx, *p.HostChainConfig)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func (k Keeper) SetHostZoneProposal(ctx sdk.Context, p *types.SetHostZoneProposa
 		return types.ErrHostZoneConfigNotFound
 	}
 
-	err = k.SetHostZoneConfig(ctx, p.HostChainConfig.IbcDenom, *p.HostChainConfig)
+	err = k.SetHostZoneConfig(ctx, *p.HostChainConfig)
 	if err != nil {
 		return err
 	}

--- a/x/feeabs/keeper/proposal_test.go
+++ b/x/feeabs/keeper/proposal_test.go
@@ -49,8 +49,8 @@ func (s *KeeperTestSuite) TestAddHostZoneProposal() {
 			err = handler(s.ctx, proposal)
 			s.Require().NoError(err)
 
-			hostChainConfig, err := s.feeAbsKeeper.GetHostZoneConfig(s.ctx, tc.hostChainConfig.IbcDenom)
-			s.Require().NoError(err)
+			hostChainConfig, found := s.feeAbsKeeper.GetHostZoneConfig(s.ctx, tc.hostChainConfig.IbcDenom)
+			s.Require().True(found)
 			s.Require().Equal(tc.hostChainConfig, hostChainConfig)
 
 			// store proposal again and it should error

--- a/x/feeabs/types/keys.go
+++ b/x/feeabs/types/keys.go
@@ -21,14 +21,20 @@ const (
 )
 
 var (
-	OsmosisTwapExchangeRate = []byte{0x01} // Key for the exchange rate of osmosis (to native token)
-	KeyChannelID            = []byte{0x02} // Key for IBC channel to osmosis
-	KeyHostChainChainConfig = []byte{0x03} // Key for IBC channel to osmosis
-	KeyPrefixEpoch          = []byte{0x04} // KeyPrefixEpoch defines prefix key for storing epochs.
+	OsmosisTwapExchangeRate          = []byte{0x01} // Key for the exchange rate of osmosis (to native token)
+	KeyChannelID                     = []byte{0x02} // Key for IBC channel to osmosis
+	KeyHostChainChainConfigByFeeAbs  = []byte{0x03} // Key for IBC channel to osmosis
+	KeyHostChainChainConfigByOsmosis = []byte{0x04} // Key for IBC channel to osmosis
+	KeyPrefixEpoch                   = []byte{0x05} // KeyPrefixEpoch defines prefix key for storing epochs.
+	KeyTokenDenomPair                = []byte{0x06} // Key store token denom pair on feeabs and osmosis
 )
 
-func GetKeyHostZoneConfig(ibcDenom string) []byte {
-	return append(KeyHostChainChainConfig, []byte(ibcDenom)...)
+func GetKeyHostZoneConfigByFeeabsIBCDenom(feeabsIbcDenom string) []byte {
+	return append(KeyHostChainChainConfigByFeeAbs, []byte(feeabsIbcDenom)...)
+}
+
+func GetKeyHostZoneConfigByOsmosisIBCDenom(osmosisIbcDenom string) []byte {
+	return append(KeyHostChainChainConfigByOsmosis, []byte(osmosisIbcDenom)...)
 }
 
 func GetKeyTwapExchangeRate(ibcDenom string) []byte {


### PR DESCRIPTION
When adding new hostzone right after send ibc query, the Iterator will not follow the ibc packet so will not successful update the twap price. Instead using Iterator, add more func to get hostzone from osmosis ibc denom