### PR TITLE
Fix: Refactor ante

### DIFF
--- a/x/feeabs/ante/decorate.go
+++ b/x/feeabs/ante/decorate.go
@@ -271,7 +271,7 @@ func (famfd FeeAbstrationMempoolFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk
 				if hostChainConfig.Frozen {
 					return ctx, sdkerrors.Wrapf(feeabstypes.ErrHostZoneFrozen, "cannot deduct fee as host zone is frozen")
 				}
-				nativeCoinsFees, err := famfd.feeabsKeeper.CalculateNativeFromIBCCoins(ctx, nonZeroCoinFeesReq, hostChainConfig)
+				nativeCoinsFees, err := famfd.feeabsKeeper.CalculateNativeFromIBCCoins(ctx, feeCoinsNonZeroDenom, hostChainConfig)
 				if err != nil {
 					return ctx, sdkerrors.Wrapf(errorstypes.ErrInsufficientFee, "insufficient fees")
 				}


### PR DESCRIPTION
should make the feeRequired and FeeCoins more clear and descriptive. 


`nonZeroCoinFeesReq` is supposed to be a native fees(in case the min-gas-prices is set as so). As a result, `CalculateNativeFromIBCCoins` shouldn't accept it as the `ibcCoins` parameters


