### PR TITLE
Fix: Fix workflow to run all interchaintest tests as expected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,13 @@ ictest-host-zone-proposal:
 	cd tests/interchaintest && go test -timeout=25m -race -v -run TestHostZoneProposal .
 
 ictest-feeabs:
-	cd tests/interchaintest && go test -timeout=25m -race -v -run TestFeeabs .
+	cd tests/interchaintest && go test -timeout=25m -race -v -run '^TestFeeAbs$$' .
 
 ictest-query-osmosis-twap:
 	cd tests/interchaintest && go test -timeout=25m -race -v -run TestQueryOsmosisTwap .
+
+# ictest-feeabs-ibc-transfer:
+# 		cd tests/interchaintest && go test -timeout=25m -race -v -run  TestIBCTransferWithFeeAbs .
 
 # Executes all tests via interchaintest after compling a local image as juno:local
 ictest-all: ictest-basic ictest-ibc ictest-packet-forward ictest-host-zone-proposal ictest-query-osmosis-twap ictest-feeabs

--- a/tests/interchaintest/feeabs/proposal.go
+++ b/tests/interchaintest/feeabs/proposal.go
@@ -45,12 +45,16 @@ func getTransaction(ctx client.Context, txHash string) (*types.TxResponse, error
 func CrossChainSwap(c *cosmos.CosmosChain, ctx context.Context, keyName string, ibcDenom string) (tx ibc.Tx, _ error) {
 	tn := getFullNode(c)
 
-	txHash, _ := tn.ExecTx(ctx, keyName,
+	txHash, err := tn.ExecTx(ctx, keyName,
 		"feeabs", "swap", ibcDenom,
 		"--gas", "auto",
 	)
 
-	if err := testutil.WaitForBlocks(ctx, 2, tn); err != nil {
+	if err != nil {
+		return tx, fmt.Errorf("executing transaction failed: %w", err)
+	}
+
+	if err := testutil.WaitForBlocks(ctx, 5, tn); err != nil {
 		return tx, err
 	}
 

--- a/tests/interchaintest/feeabs/query.go
+++ b/tests/interchaintest/feeabs/query.go
@@ -26,18 +26,18 @@ func QueryHostZoneConfigWithDenom(c *cosmos.CosmosChain, ctx context.Context, de
 	return &hostZoneConfig, nil
 }
 
-func QueryHostZoneConfig(c *cosmos.CosmosChain, ctx context.Context) (*HostChainFeeAbsConfigResponse, error) {
+func QueryAllHostZoneConfig(c *cosmos.CosmosChain, ctx context.Context) (*AllQueryHostChainConfigResponse, error) {
 	tn := getFullNode(c)
 	cmd := []string{"feeabs", "all-host-chain-config"}
 	stdout, _, err := tn.ExecQuery(ctx, cmd...)
 	if err != nil {
-		return &HostChainFeeAbsConfigResponse{}, err
+		return &AllQueryHostChainConfigResponse{}, err
 	}
 
-	var hostZoneConfig HostChainFeeAbsConfigResponse
+	var hostZoneConfig AllQueryHostChainConfigResponse
 	err = json.Unmarshal(stdout, &hostZoneConfig)
 	if err != nil {
-		return &HostChainFeeAbsConfigResponse{}, err
+		return &AllQueryHostChainConfigResponse{}, err
 	}
 
 	return &hostZoneConfig, nil

--- a/tests/interchaintest/feeabs/types.go
+++ b/tests/interchaintest/feeabs/types.go
@@ -4,6 +4,10 @@ type HostChainFeeAbsConfigResponse struct {
 	HostChainConfig HostChainFeeAbsConfig `json:"host_chain_config"`
 }
 
+type AllQueryHostChainConfigResponse struct {
+	AllHostChainConfig []HostChainFeeAbsConfig `json:"all_host_chain_config"`
+}
+
 const (
 	HostChainFeeAbsStatus_UPDATED  string = "UPDATED"
 	HostChainFeeAbsStatus_OUTDATED string = "OUTDATED"

--- a/tests/interchaintest/go.mod
+++ b/tests/interchaintest/go.mod
@@ -3,12 +3,13 @@ module github.com/osmosis-labs/fee-abstraction/tests/interchaintest
 go 1.21
 
 require (
+	cosmossdk.io/math v1.2.0
 	github.com/avast/retry-go/v4 v4.5.0
 	github.com/cosmos/cosmos-sdk v0.47.8
 	github.com/cosmos/ibc-go/v7 v7.3.1
 	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
 	github.com/osmosis-labs/fee-abstraction/v7 v7.0.0-20240308160138-d1eb119cae30
-	github.com/strangelove-ventures/interchaintest/v7 v7.0.0-20230721183422-fb937bb0e165
+	github.com/strangelove-ventures/interchaintest/v7 v7.0.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 )
@@ -24,7 +25,6 @@ require (
 	cosmossdk.io/depinject v1.0.0-alpha.4 // indirect
 	cosmossdk.io/errors v1.0.1 // indirect
 	cosmossdk.io/log v1.3.0 // indirect
-	cosmossdk.io/math v1.2.0 // indirect
 	cosmossdk.io/tools/rosetta v0.2.1 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
@@ -62,7 +62,9 @@ require (
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.4.10 // indirect
 	github.com/cosmos/iavl v0.20.1 // indirect
+	github.com/cosmos/ibc-go/modules/capability v1.0.0-rc1 // indirect
 	github.com/cosmos/ics23/go v0.10.0 // indirect
+	github.com/cosmos/interchain-security/v3 v3.1.1-0.20231102122221-81650a84f989 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.13.0 // indirect
 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect
 	github.com/creachadair/taskgroup v0.4.2 // indirect

--- a/tests/interchaintest/go.sum
+++ b/tests/interchaintest/go.sum
@@ -369,10 +369,14 @@ github.com/cosmos/gogoproto v1.4.10 h1:QH/yT8X+c0F4ZDacDv3z+xE3WU1P1Z3wQoLMBRJoK
 github.com/cosmos/gogoproto v1.4.10/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
 github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
 github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
+github.com/cosmos/ibc-go/modules/capability v1.0.0-rc1 h1:BvSKnPFKxL+TTSLxGKwJN4x0ndCZj0yfXhSvmsQztSA=
+github.com/cosmos/ibc-go/modules/capability v1.0.0-rc1/go.mod h1:A+CxAQdn2j6ihDTbClpEEBdHthWgAUAcHbRAQPY8sl4=
 github.com/cosmos/ibc-go/v7 v7.3.1 h1:bil1IjnHdyWDASFYKfwdRiNtFP6WK3osW7QFEAgU4I8=
 github.com/cosmos/ibc-go/v7 v7.3.1/go.mod h1:wvx4pPBofe5ZdMNV3OFRxSI4auEP5Qfqf8JXLLNV04g=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
+github.com/cosmos/interchain-security/v3 v3.1.1-0.20231102122221-81650a84f989 h1:Yk/2X33hHuS0mqjr4rE0ShiwPE/YflXgdyXPIYdwl+Q=
+github.com/cosmos/interchain-security/v3 v3.1.1-0.20231102122221-81650a84f989/go.mod h1:5B29fgUbUDTpBTqCnEzA2g3gI5rQG0YE/ir4isb2MEw=
 github.com/cosmos/ledger-cosmos-go v0.13.0 h1:ex0CvCxToSR7j5WjrghPu2Bu9sSXKikjnVvUryNnx4s=
 github.com/cosmos/ledger-cosmos-go v0.13.0/go.mod h1:ZcqYgnfNJ6lAXe4HPtWgarNEY+B74i+2/8MhZw4ziiI=
 github.com/cosmos/rosetta-sdk-go v0.10.0 h1:E5RhTruuoA7KTIXUcMicL76cffyeoyvNybzUGSKFTcM=
@@ -511,8 +515,9 @@ github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
-github.com/gobwas/ws v1.0.2 h1:CoAavW/wd/kulfZmSIBt6p24n4j7tHgNVCjsfHVNUbo=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gobwas/ws v1.1.0 h1:7RFti/xnNkMJnrK7D1yQ/iCIB5OrrY/54/H930kIbHA=
+github.com/gobwas/ws v1.1.0/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL0=
 github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
@@ -894,8 +899,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.20.0 h1:8W0cWlwFkflGPLltQvLRB7ZVD5HuP6ng320w2IS245Q=
-github.com/onsi/gomega v1.20.0/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
+github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
+github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
@@ -913,6 +918,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
+github.com/oxyno-zeta/gomock-extra-matcher v1.1.0 h1:Yyk5ov0ZPKBXtVEeIWtc4J2XVrHuNoIK+0F2BUJgtsc=
+github.com/oxyno-zeta/gomock-extra-matcher v1.1.0/go.mod h1:UMGTHYEmJ1dRq8LDZ7VTAYO4nqM3GD1UGC3RJEUxEz0=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
@@ -1041,8 +1048,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.16.0 h1:rGGH0XDZhdUOryiDWjmIvUSWpbNqisK8Wk0Vyefw8hc=
 github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1FofRzQg=
-github.com/strangelove-ventures/interchaintest/v7 v7.0.0-20230721183422-fb937bb0e165 h1:uVCHoklBlbAy77RT6iQBaK7oo8rTn5uI0hrRn1LL5Sw=
-github.com/strangelove-ventures/interchaintest/v7 v7.0.0-20230721183422-fb937bb0e165/go.mod h1:WUglvTs5dOXiI7z+VRiVibkFcd2pvTfoDEcXnjYONrw=
+github.com/strangelove-ventures/interchaintest/v7 v7.0.0 h1:fp7uXptYP6+8rRklBtUvIHlo507TNzMenQQJvvfDjQI=
+github.com/strangelove-ventures/interchaintest/v7 v7.0.0/go.mod h1:mkkCds7NaVUK8Bu1rmMHdkZYHmTAlICnjg/s+qQBO4A=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
@@ -1072,8 +1079,8 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
 github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
-github.com/tklauser/go-sysconf v0.3.10 h1:IJ1AZGZRWbY8T5Vfk04D9WOA5WSejdflXxP03OUqALw=
-github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
+github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
+github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//o=
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/tests/interchaintest/ibc_transfer_test.go
+++ b/tests/interchaintest/ibc_transfer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	"github.com/strangelove-ventures/interchaintest/v7"
@@ -125,7 +126,7 @@ func TestFeeabsGaiaIBCTransfer(t *testing.T) {
 	require.Equal(t, genesisWalletAmount, gaiaOrigBal)
 
 	// Compose an IBC transfer and send from feeabs -> Gaia
-	transferAmount := int64(1_000)
+	transferAmount := math.NewInt(1_000)
 	transfer := ibc.WalletAmount{
 		Address: gaiaUserAddr,
 		Denom:   feeabs.Config().Denom,
@@ -152,7 +153,7 @@ func TestFeeabsGaiaIBCTransfer(t *testing.T) {
 	// Assert that the funds are no longer present in user acc on feeabs and are in the user acc on Gaia
 	feeabsUpdateBal, err := feeabs.GetBalance(ctx, feeabsUserAddr, feeabs.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, feeabsOrigBal-transferAmount, feeabsUpdateBal)
+	require.Equal(t, feeabsOrigBal.Sub(transferAmount), feeabsUpdateBal)
 
 	gaiaUpdateBal, err := gaia.GetBalance(ctx, gaiaUserAddr, feeabsIBCDenom)
 	require.NoError(t, err)

--- a/tests/interchaintest/ibc_transfer_test.go
+++ b/tests/interchaintest/ibc_transfer_test.go
@@ -104,7 +104,7 @@ func TestFeeabsGaiaIBCTransfer(t *testing.T) {
 	)
 
 	// Create some user accounts on both chains
-	users := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), genesisWalletAmount, feeabs, gaia)
+	users := interchaintest.GetAndFundTestUsers(t, ctx, t.Name(), genesisWalletAmount.Int64(), feeabs, gaia)
 
 	// Wait a few blocks for relayer to start and for user accounts to be created
 	err = testutil.WaitForBlocks(ctx, 5, feeabs, gaia)
@@ -183,5 +183,5 @@ func TestFeeabsGaiaIBCTransfer(t *testing.T) {
 
 	gaiaUpdateBal, err = gaia.GetBalance(ctx, gaiaUserAddr, feeabsIBCDenom)
 	require.NoError(t, err)
-	require.Equal(t, int64(0), gaiaUpdateBal)
+	require.Equal(t, math.ZeroInt(), gaiaUpdateBal)
 }

--- a/tests/interchaintest/packet_foward_test.go
+++ b/tests/interchaintest/packet_foward_test.go
@@ -45,7 +45,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		channGaiaFeeabs.ChannelID,
 		channOsmosisGaia.ChannelID,
 		channGaiaOsmosis.ChannelID)
-	_, err = osmosis.ExecuteContract(ctx, osmosisUser.KeyName(), registryContractAddress, msg)
+	_, err = osmosis.ExecuteContract(ctx, osmosisUser.KeyName(), registryContractAddress, msg, "--gas", "1000000")
 	require.NoError(t, err)
 	// Execute
 	msg = `{
@@ -93,7 +93,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	queryMsg := QuerySmartMsg{
 		Packet: HasPacketForwarding{
-			ChainID: "feeabs",
+			Chain: "feeabs",
 		},
 	}
 	res := QuerySmartMsgResponse{}
@@ -106,7 +106,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	queryMsg = QuerySmartMsg{
 		Packet: HasPacketForwarding{
-			ChainID: "gaia",
+			Chain: "gaia",
 		},
 	}
 	res = QuerySmartMsgResponse{}

--- a/tests/interchaintest/query_osmosis_twap_test.go
+++ b/tests/interchaintest/query_osmosis_twap_test.go
@@ -48,7 +48,7 @@ func TestQueryOsmosisTwap(t *testing.T) {
 		channGaiaFeeabs.ChannelID,
 		channOsmosisGaia.ChannelID,
 		channGaiaOsmosis.ChannelID)
-	_, err = osmosis.ExecuteContract(ctx, osmosisUser.KeyName(), registryContractAddress, msg)
+	_, err = osmosis.ExecuteContract(ctx, osmosisUser.KeyName(), registryContractAddress, msg, "--gas", "1000000")
 	require.NoError(t, err)
 	// Execute
 	msg = `{
@@ -96,7 +96,7 @@ func TestQueryOsmosisTwap(t *testing.T) {
 	require.NoError(t, err)
 	queryMsg := QuerySmartMsg{
 		Packet: HasPacketForwarding{
-			ChainID: "feeabs",
+			Chain: "feeabs",
 		},
 	}
 	res := QuerySmartMsgResponse{}
@@ -109,7 +109,7 @@ func TestQueryOsmosisTwap(t *testing.T) {
 	require.NoError(t, err)
 	queryMsg = QuerySmartMsg{
 		Packet: HasPacketForwarding{
-			ChainID: "gaia",
+			Chain: "gaia",
 		},
 	}
 	res = QuerySmartMsgResponse{}
@@ -149,7 +149,7 @@ func TestQueryOsmosisTwap(t *testing.T) {
 	_, err = cosmos.PollForProposalStatus(ctx, feeabs, height, height+10, "2", cosmos.ProposalStatusPassed)
 	require.NoError(t, err, "proposal status did not change to passed in expected number of blocks")
 
-	_, err = feeabsCli.QueryHostZoneConfig(feeabs, ctx)
+	_, err = feeabsCli.QueryAllHostZoneConfig(feeabs, ctx)
 	require.NoError(t, err)
 
 	twap, err := feeabsCli.QueryOsmosisArithmeticTwap(feeabs, ctx, uatomOnFeeabs)

--- a/tests/interchaintest/setup.go
+++ b/tests/interchaintest/setup.go
@@ -147,6 +147,7 @@ func modifyGenesisShortProposals(votingPeriod string, maxDepositPeriod string, q
 }
 
 func SetupChain(t *testing.T, ctx context.Context) ([]ibc.Chain, []ibc.Wallet, []ibc.ChannelOutput) {
+	t.Helper()
 	client, network := interchaintest.DockerSetup(t)
 
 	rep := testreporter.NewNopReporter()
@@ -520,7 +521,7 @@ func SetupOsmosisContracts(t *testing.T,
 
 	// 3. Crosschain Swaps Contract
 	initMsg = fmt.Sprintf("{\"swap_contract\":\"%s\",\"governor\": \"%s\"}", swaprouterContractAddr, owner)
-	xcsV2ContractAddr, err := osmosis.InstantiateContract(ctx, user.KeyName(), xcsV2Wasm, initMsg, true)
+	xcsV2ContractAddr, err := osmosis.InstantiateContract(ctx, user.KeyName(), xcsV2CodeId, initMsg, true)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/interchaintest/setup.go
+++ b/tests/interchaintest/setup.go
@@ -80,7 +80,7 @@ var (
 	pathFeeabsGaia      = "feeabs-gaia"
 	pathFeeabsOsmosis   = "feeabs-osmosis"
 	pathOsmosisGaia     = "osmosis-gaia"
-	genesisWalletAmount = int64(10_000_000)
+	genesisWalletAmount = math.NewInt(10_000_000)
 	amountToSend        = math.NewInt(1_000_000_000)
 )
 

--- a/tests/interchaintest/setup.go
+++ b/tests/interchaintest/setup.go
@@ -520,7 +520,7 @@ func SetupOsmosisContracts(t *testing.T,
 	t.Logf("swap router contract address: %s\n", swaprouterContractAddr)
 
 	// 3. Crosschain Swaps Contract
-	initMsg = fmt.Sprintf("{\"swap_contract\":\"%s\",\"governor\": \"%s\"}", swaprouterContractAddr, owner)
+	initMsg = fmt.Sprintf("{\"swap_contract\":\"%s\",\"governor\": \"%s\",\"registry_contract\": \"%s\"}", swaprouterContractAddr, owner, registryContractAddr)
 	xcsV2ContractAddr, err := osmosis.InstantiateContract(ctx, user.KeyName(), xcsV2CodeId, initMsg, true)
 	if err != nil {
 		return nil, err

--- a/tests/interchaintest/setup.go
+++ b/tests/interchaintest/setup.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"cosmossdk.io/math"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/icza/dyno"
@@ -25,7 +26,7 @@ import (
 )
 
 type HasPacketForwarding struct {
-	ChainID string `json:"chain"`
+	Chain string `json:"chain"`
 }
 
 type QuerySmartMsg struct {
@@ -80,7 +81,7 @@ var (
 	pathFeeabsOsmosis   = "feeabs-osmosis"
 	pathOsmosisGaia     = "osmosis-gaia"
 	genesisWalletAmount = int64(10_000_000)
-	amountToSend        = int64(1_000_000_000)
+	amountToSend        = math.NewInt(1_000_000_000)
 )
 
 // feeabsEncoding registers the feeabs specific module codecs so that the associated types and msgs
@@ -156,7 +157,6 @@ func SetupChain(t *testing.T, ctx context.Context) ([]ibc.Chain, []ibc.Wallet, [
 	// Create chain factory with Feeabs and Gaia
 	numVals := 1
 	numFullNodes := 1
-	gasAdjustment := 2.0
 
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
 		{
@@ -181,7 +181,6 @@ func SetupChain(t *testing.T, ctx context.Context) ([]ibc.Chain, []ibc.Wallet, [
 				GasPrices:      "0.005uosmo",
 				EncodingConfig: osmosisEncoding(),
 			},
-			GasAdjustment: &gasAdjustment,
 			NumValidators: &numVals,
 			NumFullNodes:  &numFullNodes,
 		},

--- a/x/feeabs/client/cli/tx.go
+++ b/x/feeabs/client/cli/tx.go
@@ -38,9 +38,6 @@ func NewQueryOsmosisTWAPCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err != nil {
-				return err
-			}
 
 			msg := types.NewMsgSendQueryIbcDenomTWAP(clientCtx.GetFromAddress())
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)


### PR DESCRIPTION
## Changes

 + Fix running wrong test in Makefile:

  Currently `make ictest-feeabs` and `make ictest-ibc` are running the same `TestFeeabsGaiaIBCTransfer`, and the `TestFeeAbs` in feeabs_test.go is ignored because it doesn't start with `TestFeeabs`, which cause misleading tests success.
Now run the `TestFeeAbs` by exact match to save time, not sure if `make ictest-feeabs` is intended to run both the `TestFeeabsGaiaIBCTransfer` and the `TestFeeAbs`. 


+ Fix using correct code id when instantiate contract instead of bytecode path.
 
After running the TestFeeAbs, an error occur related to contract instantiation. Fixed by using correct code id when instantiate contract. 